### PR TITLE
Generate pom.xml as a workaround until Che fully supports Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.gradle/
+build/
+pom.xml
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,34 @@
 apply plugin: 'java'
 apply plugin: 'maven'
-group = 'com.codenvy.examples'
+
+group = 'org.eclipse.che.examples'
 version = '1.0-SNAPSHOT'
 description = """hello-app"""
+
 sourceCompatibility = 1.5
 targetCompatibility = 1.5
+
 jar {
     manifest {
         attributes 'Main-Class': 'org.eclipse.che.examples.HelloWorld'
     }
 }
+
 repositories {
     mavenCentral()                                                                        
 }                                                             
+
 dependencies {
     testCompile group: 'junit', name: 'junit', version:'3.8.1'
 }
+
+task createPom {
+    description "Generates a pom.xml in the project root directory; useful e.g. for IDEs which can read POM but don't directly support Gradle."
+    doLast {
+        pom {
+        }.writeTo("pom.xml")
+    }
+}
+
+compileJava.dependsOn createPom
+


### PR DESCRIPTION
see https://github.com/eclipse/che/issues/2669

Signed-off-by: Michael Vorburger <vorburger@redhat.com>